### PR TITLE
MAINT: update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ conda:
 
 sphinx:
   builder: html
+  configuration: book/conf.py
   # fail on warning is false until i get the API doc build sorted out
   fail_on_warning: false
 


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/